### PR TITLE
[FEATURE] Trying To Extract Comment Text

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -153,6 +153,7 @@ module.exports = grammar({
     code: ($) => command("code", $._arg),
     blockquote: ($) => command("blockquote", $._prim),
     pre: ($) => command("pre", $._prim),
+    comment: ($) => command("comment", $._arg),
 
     method_decl: ($) =>
       seq(


### PR DESCRIPTION
Hi @kentookura,

This a draft PR that does not yet work but I am trying to figure out how to add functionality to extract text from comments. I tried reading up on the grammar guide you mentioned in #7 but I am a bit stuck as to not knowing why this isn't working.

The comment node is defined, I thought it is set at the right priority, and I even added a command that I thought would extract text from a comment node. What am I doing wrong here? This query fails:

```scheme
(comment (_) @text.comment)
```

Obviously I am doing something wrong but am not sure exactly where.